### PR TITLE
Update BREAKINGCHANGES.md GetLanguageId part

### DIFF
--- a/BREAKINGCHANGES.md
+++ b/BREAKINGCHANGES.md
@@ -374,7 +374,7 @@ DownloadFromStream(InStream, '', '', '', OutputFileName);
 
 **Error**: _'Record Language' does not contain a definition for 'GetLanguageID'_
 
-**Solution**: Function has been moved to `codeunit 43 Language`, function `GetLanguageId`.
+**Solution**: Function has been moved to `codeunit 43 Language`, function `GetLanguageId`. If empty language code could be expected, use `GetLanguageIdOrDefault` instead.
 
 **Error**: _'Codeunit Language' does not contain a definition for 'TryGetCultureName'_
 


### PR DESCRIPTION
If someone use the GetLanguageId function in v15 e.g. to switch language on report, there is possibility to get error
`Invalid language ID: 0`
when empty language code is passed (this is default e.g. on Sales Invocies to use the default language).
Using GetLanguageIdOrDefault is the correct solution.